### PR TITLE
Added a user agent to curl command to allow download of onload package from AMD

### DIFF
--- a/bionic/Dockerfile
+++ b/bionic/Dockerfile
@@ -88,7 +88,8 @@ RUN \
         wget \
     && cd /tmp \
     && if [ -n "${ONLOAD_PACKAGE_URL}" ] ; then \
-          curl -fSL "${ONLOAD_PACKAGE_URL}" -o /tmp/onload-${ONLOAD_VERSION}-package.zip \
+          curl -H "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36" \
+          -fSL "${ONLOAD_PACKAGE_URL}" -o /tmp/onload-${ONLOAD_VERSION}-package.zip \
           && unzip /tmp/onload-${ONLOAD_VERSION}-package.zip \
           && echo "${ONLOAD_MD5SUM} onload-${ONLOAD_VERSION}.tgz" | md5sum --check \
           && tar -zxf onload-${ONLOAD_VERSION}.tgz ; \

--- a/bookworm/Dockerfile
+++ b/bookworm/Dockerfile
@@ -100,7 +100,8 @@ RUN \
           && tar xzf "onload-$(git log -1 --format="%H").tgz" \
           && cd "onload-$(git log -1 --format="%H")" ; \
     elif [ -n "${ONLOAD_PACKAGE_URL}" ] ; then \
-          curl -fSL "${ONLOAD_PACKAGE_URL}" -o /tmp/onload-${ONLOAD_VERSION}-package.zip \
+          curl -H "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36" \
+          -fSL "${ONLOAD_PACKAGE_URL}" -o /tmp/onload-${ONLOAD_VERSION}-package.zip \
           && unzip /tmp/onload-${ONLOAD_VERSION}-package.zip \
           && echo "${ONLOAD_MD5SUM} onload-${ONLOAD_VERSION}.tgz" | md5sum --check \
           && tar -zxf onload-${ONLOAD_VERSION}.tgz ; \

--- a/bullseye/Dockerfile
+++ b/bullseye/Dockerfile
@@ -100,7 +100,8 @@ RUN \
           && tar xzf "onload-$(git log -1 --format="%H").tgz" \
           && cd "onload-$(git log -1 --format="%H")" ; \
     elif [ -n "${ONLOAD_PACKAGE_URL}" ] ; then \
-          curl -fSL "${ONLOAD_PACKAGE_URL}" -o /tmp/onload-${ONLOAD_VERSION}-package.zip \
+          curl -H "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36" \
+          -fSL "${ONLOAD_PACKAGE_URL}" -o /tmp/onload-${ONLOAD_VERSION}-package.zip \
           && unzip /tmp/onload-${ONLOAD_VERSION}-package.zip \
           && echo "${ONLOAD_MD5SUM} onload-${ONLOAD_VERSION}.tgz" | md5sum --check \
           && tar -zxf onload-${ONLOAD_VERSION}.tgz ; \

--- a/buster/Dockerfile
+++ b/buster/Dockerfile
@@ -87,7 +87,8 @@ RUN \
         wget \
     && cd /tmp \
     && if [ -n "${ONLOAD_PACKAGE_URL}" ] ; then \
-          curl -fSL "${ONLOAD_PACKAGE_URL}" -o /tmp/onload-${ONLOAD_VERSION}-package.zip \
+          curl -H "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36" \
+          -fSL "${ONLOAD_PACKAGE_URL}" -o /tmp/onload-${ONLOAD_VERSION}-package.zip \
           && unzip /tmp/onload-${ONLOAD_VERSION}-package.zip \
           && echo "${ONLOAD_MD5SUM} onload-${ONLOAD_VERSION}.tgz" | md5sum --check \
           && tar -zxf onload-${ONLOAD_VERSION}.tgz ; \

--- a/centos7/Dockerfile
+++ b/centos7/Dockerfile
@@ -10,7 +10,7 @@
 #   docker run --net=host --device=/dev/onload --device=/dev/onload_epoll --device=/dev/onload_cplane -it ONLOAD_ENABLED_IMAGE_ID [COMMAND] [ARG...]
 #
 # NOTE: The host's OpenOnload version must be the same as the container's.
-# 
+#
 # Copyright (c) 2015-2021 Neomantra BV
 # Released under the MIT License, see LICENSE.txt
 #
@@ -89,7 +89,8 @@ RUN \
         which \
     && cd /tmp \
     && if [ -n "${ONLOAD_PACKAGE_URL}" ] ; then \
-          curl -fSL "${ONLOAD_PACKAGE_URL}" -o /tmp/onload-${ONLOAD_VERSION}-package.zip \
+          curl -H "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36" \
+          -fSL "${ONLOAD_PACKAGE_URL}" -o /tmp/onload-${ONLOAD_VERSION}-package.zip \
           && unzip /tmp/onload-${ONLOAD_VERSION}-package.zip \
           && echo "${ONLOAD_MD5SUM} onload-${ONLOAD_VERSION}.tgz" | md5sum --check \
           && tar -zxf onload-${ONLOAD_VERSION}.tgz ; \

--- a/centos8/Dockerfile
+++ b/centos8/Dockerfile
@@ -10,7 +10,7 @@
 #   docker run --net=host --device=/dev/onload --device=/dev/onload_epoll --device=/dev/onload_cplane -it ONLOAD_ENABLED_IMAGE_ID [COMMAND] [ARG...]
 #
 # NOTE: The host's OpenOnload version must be the same as the container's.
-# 
+#
 # Copyright (c) 2015-2021 Neomantra BV
 # Released under the MIT License, see LICENSE.txt
 #
@@ -95,7 +95,8 @@ RUN    find /etc/yum.repos.d -name 'CentOS-Linux-*' -exec sed -i 's/mirrorlist/#
         which \
     && cd /tmp \
     && if [ -n "${ONLOAD_PACKAGE_URL}" ] ; then \
-          curl -fSL "${ONLOAD_PACKAGE_URL}" -o /tmp/onload-${ONLOAD_VERSION}-package.zip \
+          curl -H "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36" \
+          -fSL "${ONLOAD_PACKAGE_URL}" -o /tmp/onload-${ONLOAD_VERSION}-package.zip \
           && ls -l /tmp \
           && unzip /tmp/onload-${ONLOAD_VERSION}-package.zip \
           && echo "${ONLOAD_MD5SUM} onload-${ONLOAD_VERSION}.tgz" | md5sum --check \

--- a/focal/Dockerfile
+++ b/focal/Dockerfile
@@ -101,7 +101,8 @@ RUN \
     && update-alternatives --set c++ /usr/bin/g++ \
     && cd /tmp \
     && if [ -n "${ONLOAD_PACKAGE_URL}" ] ; then \
-          curl -fSL "${ONLOAD_PACKAGE_URL}" -o /tmp/onload-${ONLOAD_VERSION}-package.zip \
+          curl -H "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36" \
+          -fSL "${ONLOAD_PACKAGE_URL}" -o /tmp/onload-${ONLOAD_VERSION}-package.zip \
           && unzip /tmp/onload-${ONLOAD_VERSION}-package.zip \
           && echo "${ONLOAD_MD5SUM} onload-${ONLOAD_VERSION}.tgz" | md5sum --check \
           && tar -zxf onload-${ONLOAD_VERSION}.tgz ; \
@@ -110,7 +111,7 @@ RUN \
           && echo "${ONLOAD_MD5SUM} onload-${ONLOAD_VERSION}.tgz" | md5sum --check \
           && tar -zxf onload-${ONLOAD_VERSION}.tgz \
           && mv openonload-${ONLOAD_VERSION} onload-${ONLOAD_VERSION}; \
-    fi 
+    fi
 
 RUN  cd /tmp/onload-${ONLOAD_VERSION} \
     && if [ -n "${ONLOAD_DISABLE_SYSCALL_HOOK}" ] ; then \

--- a/jammy/Dockerfile
+++ b/jammy/Dockerfile
@@ -95,7 +95,8 @@ RUN \
         wget \
     && cd /tmp \
     && if [ -n "${ONLOAD_PACKAGE_URL}" ] ; then \
-          curl -fSL "${ONLOAD_PACKAGE_URL}" -o /tmp/onload-${ONLOAD_VERSION}-package.zip \
+          curl -H "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36" \
+          -fSL "${ONLOAD_PACKAGE_URL}" -o /tmp/onload-${ONLOAD_VERSION}-package.zip \
           && unzip /tmp/onload-${ONLOAD_VERSION}-package.zip \
           && echo "${ONLOAD_MD5SUM} onload-${ONLOAD_VERSION}.tgz" | md5sum --check \
           && tar -zxf onload-${ONLOAD_VERSION}.tgz ; \
@@ -133,7 +134,7 @@ RUN \
           && rm -rf tcpdirect-${ONLOADZF_VERSION}* ; \
         fi \
     fi \
-    && DEBIAN_FRONTEND=noninteractive apt-get autoremove -y 
+    && DEBIAN_FRONTEND=noninteractive apt-get autoremove -y
 
 
 # Labels for introspection

--- a/noble/Dockerfile
+++ b/noble/Dockerfile
@@ -95,7 +95,8 @@ RUN \
         wget \
     && cd /tmp \
     && if [ -n "${ONLOAD_PACKAGE_URL}" ] ; then \
-          curl -fSL "${ONLOAD_PACKAGE_URL}" -o /tmp/onload-${ONLOAD_VERSION}-package.zip \
+          curl -H "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36" \
+          -fSL "${ONLOAD_PACKAGE_URL}" -o /tmp/onload-${ONLOAD_VERSION}-package.zip \
           && unzip /tmp/onload-${ONLOAD_VERSION}-package.zip \
           && echo "${ONLOAD_MD5SUM} onload-${ONLOAD_VERSION}.tgz" | md5sum --check \
           && tar -zxf onload-${ONLOAD_VERSION}.tgz ; \
@@ -133,7 +134,7 @@ RUN \
           && rm -rf tcpdirect-${ONLOADZF_VERSION}* ; \
         fi \
     fi \
-    && DEBIAN_FRONTEND=noninteractive apt-get autoremove -y 
+    && DEBIAN_FRONTEND=noninteractive apt-get autoremove -y
 
 
 # Labels for introspection


### PR DESCRIPTION
I guess in the past couple of days or so, AMD have updated their http server to drop requests that don't have a user-agent. By setting one the download now works again.
```
47.86   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
47.86                                  Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
48.25 curl: (92) HTTP/2 stream 0 was not closed cleanly: INTERNAL_ERROR (err 2)
------
Dockerfile:69
--------------------
  68 |     
  69 | >>> RUN \
  70 | >>>     DEBIAN_FRONTEND=noninteractive apt-get update -y \
  71 | >>>     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
  72 | >>>         autoconf \
  73 | >>>         automake \
  74 | >>>         ca-certificates \
  75 | >>>         coreutils \
  76 | >>>         curl \
  77 | >>>         ethtool \
  78 | >>>         g++ \
  79 | >>>         gcc \
  80 | >>>         kmod \
  81 | >>>         libcap-dev \
  82 | >>>         libpcap0.8-dev \
  83 | >>>         libtool-bin \
  84 | >>>         linux-libc-dev \
  85 | >>>         make \
  86 | >>>         net-tools \
  87 | >>>         patch \
  88 | >>>         perl \
  89 | >>>         python2-dev \
  90 | >>>         sed \
  91 | >>>         tar \
  92 | >>>         unzip \
  93 | >>>         util-linux \
  94 | >>>         valgrind \
  95 | >>>         wget \
  96 | >>>     && cd /tmp \
  97 | >>>     && if [ -n "${ONLOAD_PACKAGE_URL}" ] ; then \
  98 | >>>           curl -fSL "${ONLOAD_PACKAGE_URL}" -o /tmp/onload-${ONLOAD_VERSION}-package.zip \
  99 | >>>           && unzip /tmp/onload-${ONLOAD_VERSION}-package.zip \
 100 | >>>           && echo "${ONLOAD_MD5SUM} onload-${ONLOAD_VERSION}.tgz" | md5sum --check \
 101 | >>>           && tar -zxf onload-${ONLOAD_VERSION}.tgz ; \
 102 | >>>     else \
 103 | >>>           curl -fSL "${ONLOAD_LEGACY_URL}" -o /tmp/onload-${ONLOAD_VERSION}.tgz \
 104 | >>>           && echo "${ONLOAD_MD5SUM} onload-${ONLOAD_VERSION}.tgz" | md5sum --check \
 105 | >>>           && tar -zxf onload-${ONLOAD_VERSION}.tgz \
 106 | >>>           && mv openonload-${ONLOAD_VERSION} onload-${ONLOAD_VERSION}; \
 107 | >>>     fi \
 108 | >>>     && cd /tmp/onload-${ONLOAD_VERSION} \
 109 | >>>     && if [ -n "${ONLOAD_DISABLE_SYSCALL_HOOK}" ] ; then \
 110 | >>>         echo 'ONLOAD_DISABLE_SYSCALL_HOOK set, disabling CI_CFG_USERSPACE_SYSCALL' \
 111 | >>>         && sed -i 's/#define CI_CFG_USERSPACE_SYSCALL        1/#define CI_CFG_USERSPACE_SYSCALL        0 \/\/ disabled by ONLOAD_DISABLE_SYSCALL_HOOK/' ./src/include/ci/internal/transport_config_opt.h ; \
 112 | >>>     fi \
 113 | >>>     && if [ -n "${ONLOAD_USERSPACE_ID}" ] ; then \
 114 | >>>         echo "ONLOAD_USERSPACE_ID set, applying userspace interface id '${ONLOAD_USERSPACE_ID}'" \
 115 | >>>         && sed -i "s/\$\$md5/${ONLOAD_USERSPACE_ID}/" src/lib/transport/ip/mmake.mk ; \
 116 | >>>     fi \
 117 | >>>     && cd scripts \
 118 | >>>     && ./onload_build --user64 \
 119 | >>>     && ./onload_install --userfiles --nobuild \
 120 | >>>     && cd /tmp \
 121 | >>>     && rm -rf onload-${ONLOAD_VERSION}* \
 122 | >>>     && if [ -z ${ONLOAD_WITHZF} ] ; then \
 123 | >>>         rm -rf /usr/include/zf /usr/bin/zf_stackdump /usr/bin/zf_debug /usr/lib/x86_64-linux-gnu/zf /usr/lib/x86_64-linux-gnu/libonload_zf* ; \
 124 | >>>     else \
 125 | >>>         if [ -n "${ONLOADZF_PACKAGE_URL}" ] ; then \
 126 | >>>           curl -fSL "${ONLOADZF_PACKAGE_URL}" -o /tmp/tcpdirect-${ONLOADZF_VERSION}-package.zip \
 127 | >>>           && unzip /tmp/tcpdirect-${ONLOADZF_VERSION}-package.zip \
 128 | >>>           && echo "${ONLOADZF_MD5SUM} tcpdirect-${ONLOADZF_VERSION}.tgz" | md5sum --check \
 129 | >>>           && tar -zxf tcpdirect-${ONLOADZF_VERSION}.tgz \
 130 | >>>           && cd tcpdirect-${ONLOADZF_VERSION} \
 131 | >>>           && ./scripts/zf_install \
 132 | >>>           && cd /tmp \
 133 | >>>           && rm -rf tcpdirect-${ONLOADZF_VERSION}* ; \
 134 | >>>         fi \
 135 | >>>     fi \
 136 | >>>     && DEBIAN_FRONTEND=noninteractive apt-get autoremove -y
 137 |     
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c DEBIAN_FRONTEND=noninteractive apt-get update -y     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends         autoconf         automake         ca-certificates         coreutils         curl         ethtool         g++         gcc         kmod         libcap-dev         libpcap0.8-dev         libtool-bin         linux-libc-dev         make         net-tools         patch         perl         python2-dev         sed         tar         unzip         util-linux         valgrind         wget     && cd /tmp     && if [ -n \"${ONLOAD_PACKAGE_URL}\" ] ; then           curl -fSL \"${ONLOAD_PACKAGE_URL}\" -o /tmp/onload-${ONLOAD_VERSION}-package.zip           && unzip /tmp/onload-${ONLOAD_VERSION}-package.zip           && echo \"${ONLOAD_MD5SUM} onload-${ONLOAD_VERSION}.tgz\" | md5sum --check           && tar -zxf onload-${ONLOAD_VERSION}.tgz ;     else           curl -fSL \"${ONLOAD_LEGACY_URL}\" -o /tmp/onload-${ONLOAD_VERSION}.tgz           && echo \"${ONLOAD_MD5SUM} onload-${ONLOAD_VERSION}.tgz\" | md5sum --check           && tar -zxf onload-${ONLOAD_VERSION}.tgz           && mv openonload-${ONLOAD_VERSION} onload-${ONLOAD_VERSION};     fi     && cd /tmp/onload-${ONLOAD_VERSION}     && if [ -n \"${ONLOAD_DISABLE_SYSCALL_HOOK}\" ] ; then         echo 'ONLOAD_DISABLE_SYSCALL_HOOK set, disabling CI_CFG_USERSPACE_SYSCALL'         && sed -i 's/#define CI_CFG_USERSPACE_SYSCALL        1/#define CI_CFG_USERSPACE_SYSCALL        0 \\/\\/ disabled by ONLOAD_DISABLE_SYSCALL_HOOK/' ./src/include/ci/internal/transport_config_opt.h ;     fi     && if [ -n \"${ONLOAD_USERSPACE_ID}\" ] ; then         echo \"ONLOAD_USERSPACE_ID set, applying userspace interface id '${ONLOAD_USERSPACE_ID}'\"         && sed -i \"s/\\$\\$md5/${ONLOAD_USERSPACE_ID}/\" src/lib/transport/ip/mmake.mk ;     fi     && cd scripts     && ./onload_build --user64     && ./onload_install --userfiles --nobuild     && cd /tmp     && rm -rf onload-${ONLOAD_VERSION}*     && if [ -z ${ONLOAD_WITHZF} ] ; then         rm -rf /usr/include/zf /usr/bin/zf_stackdump /usr/bin/zf_debug /usr/lib/x86_64-linux-gnu/zf /usr/lib/x86_64-linux-gnu/libonload_zf* ;     else         if [ -n \"${ONLOADZF_PACKAGE_URL}\" ] ; then           curl -fSL \"${ONLOADZF_PACKAGE_URL}\" -o /tmp/tcpdirect-${ONLOADZF_VERSION}-package.zip           && unzip /tmp/tcpdirect-${ONLOADZF_VERSION}-package.zip           && echo \"${ONLOADZF_MD5SUM} tcpdirect-${ONLOADZF_VERSION}.tgz\" | md5sum --check           && tar -zxf tcpdirect-${ONLOADZF_VERSION}.tgz           && cd tcpdirect-${ONLOADZF_VERSION}           && ./scripts/zf_install           && cd /tmp           && rm -rf tcpdirect-${ONLOADZF_VERSION}* ;         fi     fi     && DEBIAN_FRONTEND=noninteractive apt-get autoremove -y" did not complete successfully: exit code: 92
```